### PR TITLE
feat: add logging and do some lint clean up

### DIFF
--- a/crates/simulate/Cargo.toml
+++ b/crates/simulate/Cargo.toml
@@ -32,3 +32,7 @@ async-trait = "0.1.68"
 left-right = "0.11.5"
 crossbeam-utils = "0.8.1"
 dyn-clone = "1"
+
+# logging
+flexi_logger = "0.25"
+log = "0.4"

--- a/crates/simulate/src/agent/agent_channel.rs
+++ b/crates/simulate/src/agent/agent_channel.rs
@@ -8,6 +8,8 @@ use crate::{
     EvmAddress,
 };
 
+use super::types::AgentId;
+
 #[derive(Debug, Clone)]
 pub struct AgentSimUpdate<U: UpdateData> {
     pub update: SimUpdate<U>,
@@ -17,15 +19,29 @@ pub struct AgentSimUpdate<U: UpdateData> {
 pub struct AgentChannel<U: UpdateData> {
     pub sender: Sender<AgentSimUpdate<U>>,
     pub address: EvmAddress,
+    pub tag: Option<Cow<'static, str>>,
 }
 
 impl<U: UpdateData> AgentChannel<U> {
+    pub fn new(sender: &Sender<AgentSimUpdate<U>>, agent_id: &AgentId) -> Self {
+        AgentChannel {
+            address: (*agent_id).address,
+            sender: sender.clone(),
+            tag: agent_id
+                .clone()
+                .name
+                .or(Some(Cow::Owned(format!("{:2X}", agent_id.address)))),
+        }
+    }
+
+    /// Sends an update to the stepper. If the tag of the AgentChannel is not none,
+    /// the update will be defaultly tagged with the AgentChannel tag.
     pub fn send(&self, update: SimUpdate<U>) {
         self.sender
             .send(AgentSimUpdate {
                 update,
                 address: self.address,
-                tag: None,
+                tag: self.tag.clone().or(None),
             })
             .map_err(ChannelError::SendError)
             .unwrap();

--- a/crates/simulations/Cargo.toml
+++ b/crates/simulations/Cargo.toml
@@ -19,3 +19,10 @@ rand.workspace = true
 crossbeam-channel.workspace = true
 
 lazy_static = "1.4.0"
+
+# Logging
+flexi_logger = "0.25"
+log = "0.4"
+
+# Binary Command Line Args
+clap = { workspace = true, features = ["derive"] }

--- a/crates/simulations/src/cozy/agents/passive_buyer.rs
+++ b/crates/simulations/src/cozy/agents/passive_buyer.rs
@@ -249,7 +249,7 @@ impl PassiveBuyer {
             self.set_logic
                 .as_ref()
                 .contract
-                .encode_function("remainingProtection", (market_id))?,
+                .encode_function("remainingProtection", market_id)?,
             None,
             None,
         ))

--- a/crates/simulations/src/cozy/agents/passive_supplier.rs
+++ b/crates/simulations/src/cozy/agents/passive_supplier.rs
@@ -87,7 +87,7 @@ impl PassiveSupplier {
             self.token
                 .as_ref()
                 .contract
-                .encode_function("balanceOf", (EthersAddress::from(self.address)))?,
+                .encode_function("balanceOf", EthersAddress::from(self.address))?,
             None,
             None,
         );

--- a/crates/simulations/src/cozy/agents/set_admin.rs
+++ b/crates/simulations/src/cozy/agents/set_admin.rs
@@ -7,13 +7,10 @@ pub use bindings::{
     set::{AccountingReturn, MarketsReturn},
 };
 use eyre::Result;
-use revm::primitives::{create_address, Env, TxEnv};
+use revm::primitives::TxEnv;
 use simulate::{
     agent::{agent_channel::AgentChannel, types::AgentId, Agent},
-    state::{
-        update::{SimUpdate, SimUpdateResult},
-        SimState,
-    },
+    state::{update::SimUpdate, SimState},
     utils::{build_call_contract_txenv, unpack_execution},
 };
 

--- a/crates/simulations/src/cozy/agents/token_deployer.rs
+++ b/crates/simulations/src/cozy/agents/token_deployer.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, collections::HashMap};
 
-use ethers::abi::Tokenize;
 use eyre::Result;
 use revm::primitives::create_address;
 use simulate::{

--- a/crates/simulations/src/cozy/agents/weth_deployer.rs
+++ b/crates/simulations/src/cozy/agents/weth_deployer.rs
@@ -11,7 +11,7 @@ use crate::cozy::{
     bindings_wrapper::*,
     utils::build_deploy_contract_tx,
     world::{CozyProtocolContract, CozyUpdate, CozyWorld},
-    EthersAddress, EvmAddress,
+    EvmAddress,
 };
 
 pub struct WethDeployer {

--- a/crates/simulations/src/cozy/mod.rs
+++ b/crates/simulations/src/cozy/mod.rs
@@ -13,8 +13,8 @@ pub use bindings::{
     drip_decay_model_constant_factory,
 };
 pub use bindings_wrapper::*;
+use ethers::types::U256 as EthersU256;
 pub use ethers::types::{Bytes as EthersBytes, H160 as EthersAddress};
-use ethers::types::{U128 as EthersU128, U256 as EthersU256};
 use eyre::Result;
 use rand::{rngs::StdRng, SeedableRng};
 use revm::primitives::U256 as EvmU256;
@@ -68,7 +68,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         Some(WETH_DEPLOYER.into()),
         EvmAddress::random_using(&mut rng),
     ));
-    sim_manager.activate_agent(weth_deployer);
+    let _ = sim_manager.activate_agent(weth_deployer);
 
     // Protocol deployer.
     let deploy_params = ProtocolDeployerParams {
@@ -94,7 +94,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         EvmAddress::random_using(&mut rng),
         deploy_params,
     ));
-    sim_manager.activate_agent(protocol_deployer);
+    let _ = sim_manager.activate_agent(protocol_deployer);
 
     let protocol_contracts = sim_manager
         .stepper
@@ -124,7 +124,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             .get(COSTMODELDYNAMICLEVELFACTORY.name)
             .unwrap(),
     ));
-    sim_manager.activate_agent(cost_models_deployer);
+    let _ = sim_manager.activate_agent(cost_models_deployer);
 
     // Drip decay models deployer
     let mut drip_decay_models = HashMap::new();
@@ -143,7 +143,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             .get(DRIPDECAYMODELCONSTANTFACTORY.name)
             .unwrap(),
     ));
-    sim_manager.activate_agent(drip_decay_models_deployer);
+    let _ = sim_manager.activate_agent(drip_decay_models_deployer);
 
     // Triggers deployer
     let mut triggers = HashMap::new();
@@ -158,7 +158,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             .unwrap(),
         protocol_contracts.get(MANAGER.name).unwrap(),
     ));
-    sim_manager.activate_agent(triggers_deployer);
+    let _ = sim_manager.activate_agent(triggers_deployer);
 
     let supplier_addr = EvmAddress::random_using(&mut rng);
     let supplier_addr2 = EvmAddress::random_using(&mut rng);
@@ -180,7 +180,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         },
         allocate_addrs,
     ));
-    sim_manager.activate_agent(token_deployer);
+    let _ = sim_manager.activate_agent(token_deployer);
 
     let world = sim_manager.stepper.sim_state_writer().world;
     let protocol_contracts = sim_manager
@@ -221,7 +221,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         protocol_contracts.get(SET.name).unwrap(),
         protocol_contracts.get(MANAGER.name).unwrap(),
     ));
-    sim_manager.activate_agent(set_admin);
+    let _ = sim_manager.activate_agent(set_admin);
 
     let passive_supplier = Box::new(PassiveSupplier::new(
         Some(PASSIVE_SUPPLIER.into()),
@@ -230,7 +230,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         protocol_contracts.get(DUMMYTOKEN.name).unwrap(),
         EthersU256::from(90000),
     ));
-    sim_manager.activate_agent(passive_supplier);
+    let _ = sim_manager.activate_agent(passive_supplier);
 
     let passive_supplier2 = Box::new(PassiveSupplier::new(
         Some((PASSIVE_SUPPLIER.to_owned() + "te").into()),
@@ -239,7 +239,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         protocol_contracts.get(DUMMYTOKEN.name).unwrap(),
         EthersU256::from(77),
     ));
-    sim_manager.activate_agent(passive_supplier2);
+    let _ = sim_manager.activate_agent(passive_supplier2);
 
     let passive_buyer = Box::new(PassiveBuyer::new(
         Some(PASSIVE_BUYER.into()),
@@ -251,7 +251,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         vec![EthersU256::from(900)],
         EthersU256::from(900000000),
     ));
-    sim_manager.activate_agent(passive_buyer);
+    let _ = sim_manager.activate_agent(passive_buyer);
 
     let passive_buyer2 = Box::new(PassiveBuyer::new(
         Some((PASSIVE_BUYER.to_owned() + "2").into()),
@@ -263,7 +263,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         vec![EthersU256::from(100)],
         EthersU256::from(100000000),
     ));
-    sim_manager.activate_agent(passive_buyer2);
+    let _ = sim_manager.activate_agent(passive_buyer2);
 
     sim_manager.run_sim();
     Ok(())

--- a/crates/simulations/src/cozy/world.rs
+++ b/crates/simulations/src/cozy/world.rs
@@ -1,8 +1,4 @@
-use std::{
-    borrow::Cow,
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use simulate::{
     contract::sim_contract::SimContract,
@@ -65,6 +61,7 @@ impl World for CozyWorld {
 
 impl CozyWorld {
     pub fn new() -> Self {
+        log::info!("Creating Cozy World");
         CozyWorld {
             protocol_contracts: HashMap::new(),
             sets: HashMap::new(),

--- a/crates/simulations/src/main.rs
+++ b/crates/simulations/src/main.rs
@@ -4,6 +4,27 @@
 use std::error::Error;
 pub mod cozy;
 
+use clap::Parser;
+use flexi_logger::{Duplicate, FileSpec, Logger};
+
+/// Runs Cozy Simulation
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Specifies the highest log level to use
+    #[arg(short, long)]
+    log_level: String,
+}
+
 pub fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    let log_level = args.log_level;
+
+    Logger::try_with_str(log_level)?
+        .log_to_stdout()
+        .duplicate_to_stderr(Duplicate::Warn)
+        .start()?;
+
     crate::cozy::run()
 }


### PR DESCRIPTION
This PR adds the https://docs.rs/flexi_logger/latest/flexi_logger/ crate, which is pretty flexible for logging. Initially, we're just logging to stdout/error, but we can configure it to log to a file later. 

We also add the https://docs.rs/clap/latest/clap/ CLI crate for adding args.

This PR also adds tags to channels by default, so that we can add results to the `update_results` hashmap so they can be logged as they're cleared.

Run the logger at the specified level with `cargo run --bin simulations -- --log-level <LEVEL> 1> logs.txt`

Some sample debug logs:

```
DEBUG [simulate::state] Protocol Deployer(B3F21A74DC0B11BEDDD69AB49B447692F7955EE3): World(None)
DEBUG [simulate::state] wETH Deployer(7F6484D7ADFCC2D45B73F9B12B09871C0D5BB408): World(None)
DEBUG [simulate::state] Dummy Token Deployer(85EE0327051853EB0258490D5B43FC3E97044DC5): World(None)
DEBUG [simulate::state] Set Admin(4DA287211304C80E9499E3D81BA9E8C904E2C8F4): Bundle(true, Success { reason: Return, gas_used: 775533, gas_refunded: 0, logs: [Log { address: 0xf50c97a6f59bfbc1a260a31c74b5ae0db09d8974, topics: [0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0, 0x0000000000000000000000000000000000000000000000000000000000000000, 0x0000000000000000000000004da287211304c80e9499e3d81ba9e8c904e2c8f4], data: b"" }, Log { address: 0xf50c97a6f59bfbc1a260a31c74b5ae0db09d8974, topics: [0xa4336c0cb1e245b95ad204faed7e940d6dc999684fd8b5e1ff597a0c4efca8ab, 0x0000000000000000000000004da287211304c80e9499e3d81ba9e8c904e2c8f4], data: b"" }, Log { address: 0x779007e5996a5bf6344f0432e6939f5dbdb19f8d, topics: [0xf44bf360523aac5984dd85fab34d6039608a1d0df0f6c435414f52c2b830c0e3], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\xf5\x0c\x97\xa6\xf5\x9b\xfb\xc1\xa2`\xa3\x1ct\xb5\xae\r\xb0\x9d\x89t" }, Log { address: 0xa9a3d7b8bfea637bd16532abbca2ad945493c325, topics: [0x6cb558fb6b2d008d5120e176cb7d5f186ae7166ee6e12b241b54552456bbcba4, 0x000000000000000000000000f50c97a6f59bfbc1a260a31c74b5ae0db09d8974, 0x000000000000000000000000779007e5996a5bf6344f0432e6939f5dbdb19f8d], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\x07\xbf\xd1\x85k#\xfc\xed\xd7^\x85\x15\xe59\x94\xa3%\xd3\xca\xe6\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x10" }, Log { address: 0xf50c97a6f59bfbc1a260a31c74b5ae0db09d8974, topics: [0x718035ddda7a43d702cbf931a9bddf02db66d3b1d2062f426046cf3dc3a08e5d, 0x0000000000000000000000000000000000000000000000000000000000000000], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\x07\xbf\xd1\x85k#\xfc\xed\xd7^\x85\x15\xe59\x94\xa3%\xd3\xca\xe6" }, Log { address: 0xf50c97a6f59bfbc1a260a31c74b5ae0db09d8974, topics: [0x8a68b2350bf2dfc661789d173442a0b6433099e04c04b4fc6e8ed32c38df45e0], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0'\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0w\x90\x07\xe5\x99j[\xf64O\x042\xe6\x93\x9f]\xbd\xb1\x9f\x8d\0\0\0\0\0\0\0\0\0\0\0\0E\xa8\x8a\x9a_<\xbe#\x12\xb6\xa5R\xf1-x\xf9\x1dsv-\0\0\0\0\0\0\0\0\0\0\0\0a\x1f#1\xd6If\xc0\x11p]<\x19\x082\xf6\xdd\x18\xda>\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0'\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" }, Log { address: 0xed296b9453635c136e9062806118df7085e1a092, topics: [0x1bf8fff61a482f21edcb49226d708f5255b3e06bb9c6485892a057058b494790, 0x000000000000000000000000857d9ea0b7b24cc9f56f51d0a8949cac4dd0d2bf], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\xf5\x0c\x97\xa6\xf5\x9b\xfb\xc1\xa2`\xa3\x1ct\xb5\xae\r\xb0\x9d\x89t" }], output: Call(b"\0\0\0\0\0\0\0\0\0\0\0\0\xf5\x0c\x97\xa6\xf5\x9b\xfb\xc1\xa2`\xa3\x1ct\xb5\xae\r\xb0\x9d\x89t") }, None)
DEBUG [simulate::state] Protocol Deployer(B3F21A74DC0B11BEDDD69AB49B447692F7955EE3): World(None)
DEBUG [simulate::state] wETH Deployer(7F6484D7ADFCC2D45B73F9B12B09871C0D5BB408): World(None)
DEBUG [simulate::state] Passive Supplier(C39BC0A27D0D743ED07FE8147642BBBC26036C67): Evm(Success { reason: Return, gas_used: 46490, gas_refunded: 0, logs: [Log { address: 0x857d9ea0b7b24cc9f56f51d0a8949cac4dd0d2bf, topics: [0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925, 0x000000000000000000000000c39bc0a27d0d743ed07fe8147642bbbc26036c67, 0x0000000000000000000000004ffe45d5f8b004a953cb9a74eb2a0a27fd145d94], data: b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" }], output: Call(b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01") })
DEBUG [simulate::state] Cost Models Deployer(B490BF9C7F979C0C7BFA313791393C4385814C26): Bundle(true, Success { reason: Return, gas_used: 674220, gas_refunded: 0, logs: [Log { address: 0x2d31c6ea47cfacdccfba2a2b2cc57d17880c2eea, topics: [0x953409edb23a2296536d6adfb290a9c79655c0f9c7b84ffaa7dee988f0586242, 0x00000000000000000000000045a88a9a5f3cbe2312b6a552f12d78f91d73762d], data: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x0b\x1a+\xc2\xecP\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0#\x86\xf2o\xc1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x0b\x1a+\xc2\xecP\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\r/\x13\xf7x\x9f\0\0" }], output: Call(b"\0\0\0\0\0\0\0\0\0\0\0\0E\xa8\x8a\x9a_<\xbe#\x12\xb6\xa5R\xf1-x\xf9\x1dsv-") }, None)
```